### PR TITLE
Ignore WM hints

### DIFF
--- a/XXkb.ad.var
+++ b/XXkb.ad.var
@@ -36,6 +36,7 @@ XXkb.controls.two_state: yes
 XXkb.controls.button_delete: yes
 XXkb.controls.button_delete_and_forget: yes
 XXkb.controls.mainwindow_delete: yes
+XXkb.controls.ignore_wm_hints: no
 
 XXkb.mousebutton.1.reverse: no
 XXkb.mousebutton.3.reverse: no

--- a/resource.c
+++ b/resource.c
@@ -115,7 +115,8 @@ struct {
 	{ "two_state",			Two_state },
 	{ "button_delete",		Button_delete },
 	{ "button_delete_and_forget",	Forget_window },
-	{ "mainwindow_delete",		Main_delete }
+	{ "mainwindow_delete",		Main_delete },
+	{ "ignore_wm_hints",		Ignore_wm_hints }
 };
 
 

--- a/xxkb.c
+++ b/xxkb.c
@@ -1147,9 +1147,9 @@ ExpectInput(Window w)
 	Bool ok = False;
 	XWMHints *hints;
 
-    if (conf.controls & Ignore_wm_hints) {
-        return True;
-    }
+	if (conf.controls & Ignore_wm_hints) {
+		return True;
+	}
 
 	hints = XGetWMHints(dpy, w);
 	if (hints != NULL) {

--- a/xxkb.c
+++ b/xxkb.c
@@ -1147,6 +1147,10 @@ ExpectInput(Window w)
 	Bool ok = False;
 	XWMHints *hints;
 
+    if (conf.controls & Ignore_wm_hints) {
+        return True;
+    }
+
 	hints = XGetWMHints(dpy, w);
 	if (hints != NULL) {
 		if ((hints->flags & InputHint) && hints->input) {

--- a/xxkb.h
+++ b/xxkb.h
@@ -23,6 +23,8 @@
 #define	Main_tray           (1<<16)
 #define	Main_ontop          (1<<17)
 
+#define Ignore_wm_hints     (1<<18)
+
 #define	SYSTEM_TRAY_REQUEST_DOCK    0
 #define	SYSTEM_TRAY_BEGIN_MESSAGE   1
 #define	SYSTEM_TRAY_CANCEL_MESSAGE  2


### PR DESCRIPTION
Some window managers (like dwm) do not specify the InputHint (window can receive input), and becuase of that xxkb ignores all windows. The XXkb.controls.ignore_wm_hints option tells xxkb to ignore this check, and allow to store/recall keyboard layout on application change.